### PR TITLE
View and delete filters, crash mitigation, update blocklist

### DIFF
--- a/app/src/main/java/com/cameron/spotifyadblocker/MainActivity.java
+++ b/app/src/main/java/com/cameron/spotifyadblocker/MainActivity.java
@@ -1,5 +1,6 @@
 package com.cameron.spotifyadblocker;
 
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
@@ -9,8 +10,9 @@ import android.util.Log;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.Toast;
+import java.util.Collection;
 
-public class MainActivity extends AppCompatActivity {
+public class MainActivity extends AppCompatActivity implements ViewAdditionalFiltersDialogFragment.ViewAdditionalFiltersDialogListener {
     private boolean enabled;
     private Intent serviceIntent;
 
@@ -48,5 +50,24 @@ public class MainActivity extends AppCompatActivity {
         preferencesEditor.putString("filter_" + newFilter, newFilter);
         preferencesEditor.apply();
         Toast.makeText(this, "Added filter: " + newFilter, Toast.LENGTH_SHORT).show();
+    }
+
+    public void openAdditionalFilterListDialog(View view) {
+        SharedPreferences preferences = getSharedPreferences("additionalFilters", MODE_PRIVATE);
+        Collection<? extends String> additionalFilters = (Collection<String>) preferences.getAll().values();
+        ViewAdditionalFiltersDialogFragment viewAdditionalFiltersDialogFragment = ViewAdditionalFiltersDialogFragment.newInstance(additionalFilters.toArray(new String[additionalFilters.size()]));
+        viewAdditionalFiltersDialogFragment.show(getFragmentManager(), "additionalFiltersDialog");
+    }
+
+    @Override
+    public void onFilterClick(DialogInterface dialogInterface, int i) {
+        SharedPreferences.Editor preferencesEditor = getSharedPreferences("additionalFilters", MODE_PRIVATE).edit();
+
+        SharedPreferences preferences = getSharedPreferences("additionalFilters", MODE_PRIVATE);
+        Collection<String> additionalFilters = (Collection<String>) preferences.getAll().values();
+        String filterToRemove = additionalFilters.toArray(new String[additionalFilters.size()])[i];
+        preferencesEditor.remove("filter_" + filterToRemove);
+        Toast.makeText(this, "Deleted filter: " + filterToRemove, Toast.LENGTH_SHORT).show();
+        preferencesEditor.apply();
     }
 }

--- a/app/src/main/java/com/cameron/spotifyadblocker/NotificationListener.java
+++ b/app/src/main/java/com/cameron/spotifyadblocker/NotificationListener.java
@@ -105,8 +105,12 @@ public class NotificationListener extends NotificationListenerService {
     @Override
     public void onDestroy() {
         Log.d("DEBUG", "Destroying Service");
-        killService();
-        Log.d("DEBUG", "Timer canceled.");
+        try {
+            killService();
+            Log.d("DEBUG", "Timer canceled.");
+        } catch (NullPointerException ex) {
+            Log.w("WARN", "NullPointer encountered while cancelling timer.");
+        }
     }
 
     @Override

--- a/app/src/main/java/com/cameron/spotifyadblocker/ViewAdditionalFiltersDialogFragment.java
+++ b/app/src/main/java/com/cameron/spotifyadblocker/ViewAdditionalFiltersDialogFragment.java
@@ -1,0 +1,52 @@
+package com.cameron.spotifyadblocker;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.app.DialogFragment;
+import android.content.DialogInterface;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+
+import static android.content.Context.MODE_PRIVATE;
+
+/**
+ * Created by leapwill on 2017-07-05.
+ */
+
+public class ViewAdditionalFiltersDialogFragment extends DialogFragment {
+
+    ViewAdditionalFiltersDialogListener listener;
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle("Tap to delete");
+        builder.setItems(getArguments().getCharSequenceArray("additionalFilters"), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialogInterface, int i) {
+                listener.onFilterClick(dialogInterface, i);
+            }
+        });
+        return builder.create();
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        listener = (ViewAdditionalFiltersDialogListener) activity;
+    }
+
+    public static ViewAdditionalFiltersDialogFragment newInstance(CharSequence[] additionalFilters) {
+
+        Bundle args = new Bundle();
+        args.putCharSequenceArray("additionalFilters", additionalFilters);
+        ViewAdditionalFiltersDialogFragment fragment = new ViewAdditionalFiltersDialogFragment();
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    interface ViewAdditionalFiltersDialogListener {
+        void onFilterClick(DialogInterface dialogInterface, int i);
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -100,4 +100,14 @@
         android:text="If you hear an ad, you can add the title to the filter list. Toggle blocking to apply changes."
         android:textAlignment="center" />
 
+    <Button
+        android:id="@+id/button2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/textView2"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="24dp"
+        android:onClick="openAdditionalFilterListDialog"
+        android:text="View Your Filters" />
+
 </RelativeLayout>

--- a/app/src/main/res/raw/blocklist.txt
+++ b/app/src/main/res/raw/blocklist.txt
@@ -78,6 +78,7 @@ Paramount
 Paramount Pictures
 Pistols at Dawn
 ProFlowers
+Pursue Beer
 Red Bull
 Samsung
 Sheetz
@@ -94,6 +95,7 @@ Squarespace
 Starbucks
 State Farm
 Subway
+Summertime Tacos
 Target
 TaxACT
 Texas Lottery


### PR DESCRIPTION
* add ability to view and delete user filters: in a dialog list accessible from Main
* postpone a crash from app start to enabling blocking: I was getting a NullPointerException when opening the app, so I added a try/catch that postponed it to enabling blocking. I solved it by clearing app data.
* update blocklist